### PR TITLE
Require Django version < 2.0 for now (otherwise tests fail)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     description=LONG_DESCRIPTION.strip(),
     long_description=parse_markdown_readme(),
     install_requires=[
-        'Django>=1.8',
+        'Django>=1.8,<2.0',
         'djangorestframework>=3.3.3',
         'django-mustache',
         'html-json-forms',


### PR DESCRIPTION
Error with Django 2.0:
  File ".../wq.db/.eggs/python_social_auth-0.2.21-py3.4.egg/social/apps/django_app/default/models.py", line 33, in AbstractUserSocialAuth
      user = models.ForeignKey(USER_MODEL, related_name='social_auth')
  TypeError: __init__() missing 1 required positional argument: 'on_delete'