### PR TITLE
make compatible with DRF 1.12 working with Django 3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         'Django>=1.11,<4.0',
-        'djangorestframework>=3.8.0,<3.12',
+        'djangorestframework>=3.8.0,<3.13',
         'django-mustache',
         'html-json-forms',
         'natural-keys>=1.6.0',


### PR DESCRIPTION
Hi! I couldn't get DRF 3.11 working with Django 3.1, but upgrading to 3.12 fixed all the issues.

Can we have this patch released also as wq.db v1.2.2?